### PR TITLE
Fix: monsters with a URL source (e.g. Monster-A-Day) not appearing in list

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -11345,14 +11345,16 @@ var Monster = /*#__PURE__*/function () {
           location = _str$split2[1];
 
       var source = {};
+      var reference = _this.app.sources[book];
 
       if (!isNaN(location)) {
-        source.reference = _this.app.sources[book];
+        source.reference = reference;
         source.page = location;
       } else if (_lib_js__WEBPACK_IMPORTED_MODULE_1__.isValidHttpUrl(location)) {
         source.reference = {
-          name: book,
-          shortname: book,
+          name: reference.name,
+          shortname: reference.shortname,
+          enabled: reference.enabled,
           link: location
         };
       }

--- a/src/js/monster.js
+++ b/src/js/monster.js
@@ -45,13 +45,15 @@ export default class Monster {
         this.sources = this.data.sources.split(', ').map(str => {
             const [book, location] = str.split(": ");
             let source = {};
+            const reference = this.app.sources[book];
             if (!isNaN(location)) {
-                source.reference = this.app.sources[book];
+                source.reference = reference;
                 source.page = location;
             } else if (lib.isValidHttpUrl(location)) {
                 source.reference = {
-                    name: book,
-                    shortname: book,
+                    name: reference.name,
+                    shortname: reference.shortname,
+                    enabled: reference.enabled,
                     link: location
                 }
             }


### PR DESCRIPTION
This is a fix for the issue of Monster-A-Day monsters not being shown when that source has been enabled. Let me know if there's anything else that should be part of this PR!

<img width="765" alt="Screen Shot 2022-05-26 at 8 56 31 AM" src="https://user-images.githubusercontent.com/153104/170492263-931bcd62-6d20-4e56-90cc-c762b20f4bb5.png">
