### PR TITLE
Quick Fix to Source Issue

### DIFF
--- a/src/js/monster.js
+++ b/src/js/monster.js
@@ -64,7 +64,7 @@ export default class Monster {
         }
       }
 
-      let reference = sources.find(book);
+      let reference = sources.find(book) || { name: book, enabled: true };
       return {
         actual_source: reference,
         reference: {


### PR DESCRIPTION
Addresses Issue #29 

sources.find(book) is undefined if it didn't already exist which doesn't really jive with the whole 'custom sources' having custom names thing.

I thought for a moment maybe "Custom Source" was already loaded in the list of existing sources but it wasn't.  Regardless, that name had uniquely good behavior while all others I tried didn't. Didn't wanna get too deep in it but I found *a* fix to my issue that seems to work fine.