### PR TITLE
Table improvements

### DIFF
--- a/src/components/MonsterTable.vue
+++ b/src/components/MonsterTable.vue
@@ -171,7 +171,7 @@ onBeforeMount(() => {
             />
             <MonsterTableHeading
               label="Alignment"
-              class="hidden lg:table-cell w-32 text-right pr-4"
+              class="hidden xl:table-cell w-32 text-right pr-4"
             />
           </tr>
         </thead>

--- a/src/components/MonsterTable.vue
+++ b/src/components/MonsterTable.vue
@@ -146,20 +146,16 @@ onBeforeMount(() => {
               @sort="setSortBy($event)"
             />
             <MonsterTableHeading
+              label="Alignment"
+              class="hidden xl:table-cell w-32 text-right pr-4"
+            />
+            <MonsterTableHeading
               label="Size"
               sorts-column="size"
               :sort-by="sortBy"
               :sort-by-desc="sortByDesc"
               class="table-cell w-32"
               @sort="setSortBy($event)"
-            />
-            <MonsterTableHeading
-              label="CR"
-              sorts-column="cr.numeric"
-              :sort-by="sortBy"
-              :sort-by-desc="sortByDesc"
-              @sort="setSortBy($event)"
-              class="hidden sm:table-cell w-32"
             />
             <MonsterTableHeading
               label="Type"
@@ -170,8 +166,12 @@ onBeforeMount(() => {
               @sort="setSortBy($event)"
             />
             <MonsterTableHeading
-              label="Alignment"
-              class="hidden xl:table-cell w-32 text-right pr-4"
+              label="CR"
+              sorts-column="cr.numeric"
+              :sort-by="sortBy"
+              :sort-by-desc="sortByDesc"
+              @sort="setSortBy($event)"
+              class="hidden sm:table-cell w-32"
             />
           </tr>
         </thead>

--- a/src/components/MonsterTableRow.vue
+++ b/src/components/MonsterTableRow.vue
@@ -56,6 +56,10 @@ const encounter = useEncounter();
       </dl>
     </td>
     <td
+      class="hidden px-3 pl-2 pr-4 text-sm text-gray-500 dark:text-gray-300 xl:table-cell w-32 text-right"
+      v-text="monster.alignment.string"
+    ></td>
+    <td
       class="px-3 py-2 text-sm text-gray-500 dark:text-gray-300 table-cell w-32 max-w-32 truncate"
     >
       <span class="truncate" v-text="monster.size"></span>
@@ -93,6 +97,10 @@ const encounter = useEncounter();
       </dl>
     </td>
     <td
+      class="hidden px-3 py-2 text-sm text-gray-500 dark:text-gray-300 lg:table-cell w-32"
+      v-text="monster.type"
+    ></td>
+    <td
       class="hidden px-3 py-2 text-sm text-gray-500 dark:text-gray-300 sm:table-cell w-32"
     >
       <span
@@ -118,13 +126,5 @@ const encounter = useEncounter();
         ></span>
       </span>
     </td>
-    <td
-      class="hidden px-3 py-2 text-sm text-gray-500 dark:text-gray-300 lg:table-cell w-32"
-      v-text="monster.type"
-    ></td>
-    <td
-      class="hidden px-3 pl-2 pr-4 text-sm text-gray-500 dark:text-gray-300 xl:table-cell w-32 text-right"
-      v-text="monster.alignment.string"
-    ></td>
   </tr>
 </template>

--- a/src/components/MonsterTableRow.vue
+++ b/src/components/MonsterTableRow.vue
@@ -35,6 +35,11 @@ const encounter = useEncounter();
           {{ tag.toLowerCase() }}
         </Badge>
       </span>
+      <dt class="sr-only sm:hidden">Type</dt>
+      <dd
+        class="mt-1 truncate text-gray-500 dark:text-gray-400 lg:hidden"
+        v-text="monster.type"
+      ></dd>
       <dl class="font-normal">
         <dt class="sr-only">Sources</dt>
         <dd class="mt-1 truncate text-gray-500 dark:text-gray-400">
@@ -48,11 +53,6 @@ const encounter = useEncounter();
             "
           ></span>
         </dd>
-        <dt class="sr-only sm:hidden">Type</dt>
-        <dd
-          class="mt-1 truncate text-gray-500 dark:text-gray-400 lg:hidden"
-          v-text="monster.type"
-        ></dd>
       </dl>
     </td>
     <td
@@ -114,7 +114,7 @@ const encounter = useEncounter();
           v-text="
             ' (' + encounter.getDifficultyFromExperience(monster.cr.exp) + ')'
           "
-          class="text-xs"
+          class="text-xs hidden xl:inline"
         ></span>
       </span>
     </td>
@@ -123,7 +123,7 @@ const encounter = useEncounter();
       v-text="monster.type"
     ></td>
     <td
-      class="hidden px-3 pl-2 pr-4 text-sm text-gray-500 dark:text-gray-300 lg:table-cell w-32 text-right"
+      class="hidden px-3 pl-2 pr-4 text-sm text-gray-500 dark:text-gray-300 xl:table-cell w-32 text-right"
       v-text="monster.alignment.string"
     ></td>
   </tr>


### PR DESCRIPTION
This PR makes four relatively minor changes, to help address the usability problems on certain screen sizes to fix #32:

- Reorders columns to almost "read" like a sentence, such that `Size - CR - Type - Alignment` becomes `Alignment - Size - Type - CR`.
  - Example: `Medium - 1/4 - Humanoid - neutral good` becomes `neutral good - Medium - Humanoid - 1/4`
- Hides the `(Difficulty)` labels on smaller screens
- Hides the Alignment column longer (until xl, rather than lg)
- Moves type above sources on the "stacked" table in the smallest screen size

Before:
![koboldplus club_](https://github.com/fantasycalendar/kobold-plus-fight-club/assets/2779682/812603c4-37f5-408a-93d7-bf01f3018175)

After:
![localhost_3000_](https://github.com/fantasycalendar/kobold-plus-fight-club/assets/2779682/955802a2-0143-4465-9d1c-b99aa1c4c49c)
