### PR TITLE
Move Search Keyboard Shortcut Label

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -68,7 +68,8 @@ onMounted(() => {
           />
 
           <div
-            class="absolute inset-y-0 right-0 flex py-1.5 pr-2 hidden md:block"
+            class="absolute inset-y-0 right-0 py-1.5 pr-2 grid place-items-center"
+            :class="{ 'right-8': filters.search.length }"
           >
             <kbd
               class="inline-flex items-center border border-gray-200 dark:border-gray-600 rounded px-2 text-sm font-sans font-medium text-gray-400"


### PR DESCRIPTION
This PR fixes #26 by having the keyboard shortcut label move over a bit when a search is entered:


![2023-11-17_08-45](https://github.com/fantasycalendar/kobold-plus-fight-club/assets/2779682/f53c031c-16b1-42c9-970b-e93e0ef5b80f)
