### PR TITLE
Fix Environment Filtering

### DIFF
--- a/src/components/FiltersSlideover.vue
+++ b/src/components/FiltersSlideover.vue
@@ -165,6 +165,7 @@ defineProps({
                   <Multiselect
                     mode="tags"
                     placeholder="Any Environment"
+                    noOptionsText="No monsters in active sources have environments"
                     v-model="filters.environment"
                     valueProp="valueProp"
                     label="label"

--- a/src/js/monster.js
+++ b/src/js/monster.js
@@ -13,7 +13,7 @@ export default class Monster {
     this.type = attributes.type;
     this.size = attributes.size;
     this.hp = attributes.hp;
-    this.environment = attributes.environment.toLowerCase();
+    this.environment = attributes.environment.toLowerCase().split(',').map(env => env.trim());
     this.isUnique = !!attributes["unique?"] || !!attributes["unique"];
     this.lair = !!attributes["lair"] || !!attributes["lair?"];
 

--- a/src/stores/filters.js
+++ b/src/stores/filters.js
@@ -270,9 +270,9 @@ export const useFilters = defineStore("filters", {
       let results = new Set(
         useMonsters()
           .all.filter(Boolean)
+          .filter(monster => monster.sourceEnabled)
           .map((monster) => {
             return monster.environment
-              .split(",")
               .map(
                 (item) =>
                   item.trim().toUpperCase().slice(0, 1) +


### PR DESCRIPTION
This PR fixes #37 by converting each monster's environment list into an array on instantiation.

It also:
- Updates the filter to only show environments from monsters in active sources
- Adds "no options" text to the environment filter for when there are no environments available in any active monsters
