### PR TITLE
Keyboard Shortcut Fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ onMounted(async () => {
   );
 
   hotkeys.register(
-    "ctrl+shift+\\",
+    "ctrl+shift+\\, command+shift+\\",
     "Toggles light/dark theme",
     () => {
       toggleTheme();

--- a/src/components/KeyboardModal.vue
+++ b/src/components/KeyboardModal.vue
@@ -6,6 +6,16 @@ import { onBeforeMount } from "vue";
 
 const modals = useModals();
 const hotkeys = useHotkeys();
+const mac = navigator.platform.startsWith('Mac');
+
+// If the hotkey is "ctrl+/, command+/", then we want to only display "⌘+/" on Mac
+// and "Ctrl+/" everywhere else. If the hotkey has no ctrl or command modifiers, 
+// such as "esc", then we want to display just "Esc" everywhere.
+function formatHotkey(hotkey) {
+    return (hotkey.includes("ctrl") && hotkey.includes("command")) 
+      ? hotkey.split(", ")[mac ? 1 : 0].replace("command", "⌘").replace("ctrl", "Ctrl")
+      : hotkey.slice(0, 1).toUpperCase() + hotkey.slice(1);
+}
 
 onBeforeMount(() => {
   hotkeys.register(
@@ -27,12 +37,12 @@ onBeforeMount(() => {
       <div
         class="my-2 max-h-96 overflow-y-auto overflow-x-hidden text-gray-700 dark:text-gray-300"
       >
-        <div class="grid grid-cols-2 gap-x-4 gap-y-2">
+        <div class="grid grid-cols-2 gap-x-8 gap-y-3">
           <div v-for="hotkey in hotkeys.help" :key="hotkey.shortcut">
             <div class="flex justify-between">
               <kbd
                 class="inline-flex items-center border border-gray-200 dark:border-gray-600 rounded px-2 text-sm font-sans font-medium text-gray-400"
-                v-text="hotkey.shortcut"
+                v-text="formatHotkey(hotkey.shortcut)"
               ></kbd>
               <div v-text="hotkey.description"></div>
             </div>

--- a/src/components/KeyboardModal.vue
+++ b/src/components/KeyboardModal.vue
@@ -9,7 +9,7 @@ const hotkeys = useHotkeys();
 
 onBeforeMount(() => {
   hotkeys.register(
-    "ctrl+/",
+    "ctrl+/, command+/",
     "Displays this help window",
     () => {
       modals.toggle("keyboard");

--- a/src/components/MonsterTable.vue
+++ b/src/components/MonsterTable.vue
@@ -101,7 +101,7 @@ const pagination = computed(() => {
 
 onBeforeMount(() => {
   hotkeys.register(
-    "ctrl+[",
+    "ctrl+[, command+[",
     "Previous monsters search page",
     () => {
       currentPage.value--;
@@ -111,7 +111,7 @@ onBeforeMount(() => {
   );
 
   hotkeys.register(
-    "ctrl+]",
+    "ctrl+], command+]",
     "Next monsters search page",
     () => {
       currentPage.value++;

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -14,7 +14,7 @@ const searchBox = ref(null);
 
 onMounted(() => {
   hotkeys.register(
-    "ctrl+k",
+    "ctrl+k, command+k",
     "Focus the search box",
     () => {
       searchBox.value.focus();

--- a/src/views/GeneratorView.vue
+++ b/src/views/GeneratorView.vue
@@ -36,7 +36,7 @@ export default {
   data() {
     return {
       userWantsFilters: this.filtersTest(),
-      alwaysShowFilters: false,
+      alwaysShowFilters: this.filtersTest(),
       mobileEncounterTab: false,
     };
   },
@@ -69,10 +69,12 @@ export default {
 
     setupHotkeys() {
       this.hotkeys.register(
-        "ctrl+f",
+        "ctrl+f, command+f",
         "Toggle the filters sidebar",
         () => {
-          this.userWantsFilters = this.filtersTest() ? true : !this.userWantsFilters;
+          this.userWantsFilters = this.filtersTest()
+            ? true
+            : !this.userWantsFilters;
 
           return false;
         },
@@ -80,7 +82,7 @@ export default {
       );
 
       this.hotkeys.register(
-        "ctrl+s",
+        "ctrl+s, command+s",
         "Save the current encounter",
         () => {
           this.encounter.save();
@@ -90,7 +92,7 @@ export default {
       );
 
       this.hotkeys.register(
-        "ctrl+g",
+        "ctrl+g, command+g",
         "Generate an encounter",
         () => {
           this.encounter.generateRandom();

--- a/src/views/GeneratorView.vue
+++ b/src/views/GeneratorView.vue
@@ -1,4 +1,3 @@
-show
 <script setup></script>
 
 <script>


### PR DESCRIPTION
Keyboard shortcuts are currently _only_ setup to listen for `ctrl`. This PR sets up hotkeys-js to allow for `command` as well, fixing #27
