### PR TITLE
Fix CSV importer bug

### DIFF
--- a/src/js/importer.js
+++ b/src/js/importer.js
@@ -241,7 +241,7 @@ export default class Importer {
             return validSources;
         }
 
-        const validMonsters = this._validateMonsters(results.monsters, validSources);
+        const validMonsters = this._validateMonsters(results.monsters, results.sources);
         if(!validMonsters[0]){
             return validMonsters;
         }


### PR DESCRIPTION
## Change details
The CSV importer currently doesn't work due to a bug. When downloading the template CSV files, and then attempting to import them into KFC, the following error appears: `Monster 'Zombie' has the source 'Custom Source', but it is not defined in the sources!`

This is because `validSources` is an array with the success flag at element 0 and the sources array at element 1. By passing `results.sources` to `_validateMonsters()` (the same way `_validateJsonFile` and `_validateJson` do) we only send the sources array.

## Testing
Hosted the site locally with `npm run dev` and imported the example CSV files, as well as my own custom monsters+sources CSV, and checked that the error didn't show up and the monsters appear in the table correctly.