### PR TITLE
Fix Downloading Example CSVs

### DIFF
--- a/src/js/importer.js
+++ b/src/js/importer.js
@@ -256,17 +256,17 @@ export default class Importer {
                             <input name="import_resource_locator" id="import_resource_locator" type="text" v-model="importerResourceLocator">
                         `,
         'json-raw': `
-                            <label class="mb-1" for="import_resource_locator">Input raw JSON or <a href="javascript:true" class="primary-link" @click="$emit('downloadExample')">download an example file to edit.</a></label>
+                            <label class="mb-1" for="import_resource_locator">Input raw JSON or <a href="javascript:;" class="primary-link" @click="$emit('downloadExample')">download an example file to edit.</a></label>
                             <div class="mt-1">
                                 <textarea id="import_resource_locator" v-model="importerResourceLocator" rows="4" name="comment" class="border-gray-300 focus:ring-emerald-500 focus:border-emerald-500 block w-full rounded-md lg:rounded-r-none sm:text-sm disabled:text-gray-500 disabled:bg-gray-300 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400 text-gray-600"></textarea>
                             </div>
                         `,
         'json-file': `
-                            <label class="mb-1 block" id="file_input_label" for="import_resource_locator_file">Upload JSON text file below or <a class="primary-link" href="javascript:true" @click="$emit('downloadExample')">download an example file to edit.</a></label>                
+                            <label class="mb-1 block" id="file_input_label" for="import_resource_locator_file">Upload JSON text file below or <a class="primary-link" href="javascript:;" @click="$emit('downloadExample')">download an example file to edit.</a></label>                
                             <input accept="application/json" class="block w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 cursor-pointer dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400" @change="importerResourceLocator = $event.target.files[0]" aria-describedby="file_input_label" id="import_resource_locator_file" type="file">
                         `,
         'csv-file': `
-                            <label class="mb-1">Upload CSV text files below or <a class="primary-link" href="javascript:true" @click="$emit('downloadExample')">download example files to edit.</a></label>
+                            <label class="mb-1">Upload CSV text files below or <a class="primary-link" href="javascript:;" @click="$emit('downloadExample')">download example files to edit.</a></label>
                             <div class="grid grid-cols-2 gap-2 mt-2">                
                                 <label class="" id="file_input_label_1" for="import_resource_locator_file_1">Sources CSV</label>                
                                 <label class="" id="file_input_label_2" for="import_resource_locator_file_2">Monsters CSV</label>                


### PR DESCRIPTION
Currently, downloading the example CSVs is broken - It just replaces the current page with the string "true".

This PR addresses that.
